### PR TITLE
correct display problem for non-English  words

### DIFF
--- a/application/include/functions.php
+++ b/application/include/functions.php
@@ -152,6 +152,7 @@ function send_phpmailer($email, $subject, $message)
         $mail->addReplyTo(get_config('smtp_mail'));
 
         // Content
+	$mail->CharSet = 'UTF-8';
         $mail->isHTML(true);
         $mail->Subject = $subject;
         $mail->Body = $message;


### PR DESCRIPTION
add $mail->CharSet = 'UTF-8' to make the mail can support non-English locale like Chinese