### PR TITLE
Pass database port from settings to DriverManager

### DIFF
--- a/application/include/database.php
+++ b/application/include/database.php
@@ -20,6 +20,7 @@ class database
             'user' => get_config('db_auth_user'),
             'password' => get_config('db_auth_pass'),
             'host' => get_config('db_auth_host'),
+            'port' => get_config('db_auth_port'),
             'driver' => 'pdo_mysql',
             'charset' => 'utf8',
         ], new Configuration());
@@ -33,6 +34,7 @@ class database
                         'user' => $realm["db_user"],
                         'password' => $realm["db_pass"],
                         'host' => $realm["db_host"],
+                        'port' => $realm["db_port"],
                         'driver' => 'pdo_mysql',
                         'charset' => 'utf8',
                     ], new Configuration());


### PR DESCRIPTION
Or else it will use the default database port (3306), even if you configured a different one.

I was running this app and was having an "Access denied" error, even if the credentials were correct. Then I noticed that the port value was not being passed to the database DriverManager instances and I was running another database server on the default MySQL port. This fixed my issue.